### PR TITLE
Include tests data files in sdist so tests can be run

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,7 @@
 recursive-include doc *.html *.css *.txt *.js *.jpg *.png *.py Makefile *.rst *.mako *.sty
 recursive-include examples *.py
 recursive-include tests *.py *.dat
+recursive-include tests/files *
 
 include README* LICENSE distribute_setup.py ez_setup.py CHANGES*
 prune doc/build/output


### PR DESCRIPTION
While the test*.py files get included by the MANIFEST.in, the actual data files they use do not.

This changes MANIFEST.in to include those files also